### PR TITLE
Add implicit iteration example from slide 65

### DIFF
--- a/examples/implicit-iteration.cf
+++ b/examples/implicit-iteration.cf
@@ -1,0 +1,12 @@
+bundle agent main
+{
+  vars:
+      "l" slist => { "two", "one", "three" };
+      "d" data => '[ "three", "one", "two"]';
+      "d2" data => '{ "one":"1", "two":"2", "three":"3" }';
+
+  reports:
+      "l contains $(l)";
+      "d contains $(d)";
+      "d2 contains $(d2)";
+}


### PR DESCRIPTION
Just copy the example from slide 65, to make it easier to run it for those following along.